### PR TITLE
Prefix all messages with application name

### DIFF
--- a/msg.c
+++ b/msg.c
@@ -40,11 +40,14 @@
 void vfmsg(FILE *f,
         const char *pre, const char *suf, const char *fmt,
         va_list ap) {
-    int prelen = 0, fmtlen = 0, suflen = 0;
+    int prelen = 0, fmtlen = 0, suflen = 0, proglen = 0;
+    char prog[30] = "[reattach-to-user-namespace] ";
+    proglen = strlen(prog);
     if (pre) prelen = strlen(pre);
     if (fmt) fmtlen = strlen(fmt);
     if (suf) suflen = strlen(suf);
     char *newfmt = malloc(
+            proglen*2 +
             prelen*2 + /* %-doubled pre */
             fmtlen +
             2 + /* ':' and SP */
@@ -55,6 +58,10 @@ void vfmsg(FILE *f,
         goto finish;
 
     char *newfmt_end = newfmt;
+    if(proglen) {
+      strcpy(newfmt_end, prog);
+      newfmt_end += proglen;
+    }
     if (prelen)
         while(*pre)
             if ((*newfmt_end++ = *pre++) == '%')


### PR DESCRIPTION
When I updated to 10.7 I started getting a error message in my terminal. Didn't know where it came from but I had my suspicions. I think it would be nice to prefix all error messages with the application name to make it obvious where the message came from.

I'm no C programmer but I have attached a patch.
