### PR TITLE
Usage.md: curl / macOS Sierra / SecureTransport

### DIFF
--- a/Usage.md
+++ b/Usage.md
@@ -181,5 +181,16 @@ alleviate.
 
 [issue 54]: https://github.com/ChrisJohnsen/tmux-MacOSX-pasteboard/issues/54
 
+* `curl` using certificates in Keychain to verify peer
+
+    > `--cacert`
+    > (iOS and macOS only) If curl is built against Secure Transport [...] then
+    > curl will use the certificates in the system and user Keychain to verify
+    > the peer, which is the preferred method of verifying the peer's
+    > certificate chain.
+    
+    As of macOS Sierra, under tmux without `reattach-to-user-namespace`, `curl`
+    will fail to verify peers against Keychain-stored certificates.
+
 There may also be other contexts (aside from “inside *tmux*”) where
 these same problems occur, but I have not yet heard of any.


### PR DESCRIPTION
Under macOS, `curl` verifies peers using certificates stored in Keychain. As of macOS Sierra this does not work under tmux without `reattach-to-user-namespace`.

I thought it worth adding to `Usage.md` as Google finds no other mention of this issue, and it had me stumped until a wild guess and trying it under `reattach-to-user-namespace`.

---

Excerpt of curl's man page:

> --cacert <CA certificate>
> (SSL) Tells curl to use the specified certificate file to verify the peer.
> (iOS and macOS only) If curl is built against Secure Transport, then this option is supported for backward compatibility with other SSL engines, but it should not be set. If the option is not set, then curl will use the certificates in the system and user Keychain to verify  the  peer,  which  is  the  preferred method of verifying the peer's certificate chain.

Demonstration:

```
$ uname -a
Darwin paulbookpro.local 16.3.0 Darwin Kernel Version 16.3.0: Thu Nov 17 20:23:58 PST 2016; root:xnu-3789.31.2~1/RELEASE_X86_64 x86_64
```

```
$ curl --version
curl 7.51.0 (x86_64-apple-darwin16.0) libcurl/7.51.0 SecureTransport zlib/1.2.8
Protocols: dict file ftp ftps gopher http https imap imaps ldap ldaps pop3 pop3s rtsp smb smbs smtp smtps telnet tftp
Features: AsynchDNS IPv6 Largefile GSS-API Kerberos SPNEGO NTLM NTLM_WB SSL libz UnixSockets
```

```
$ curl https://example.dev/
curl: (60) SSL certificate problem: Invalid certificate chain
More details here: https://curl.haxx.se/docs/sslcerts.html

curl performs SSL certificate verification by default, using a "bundle"
 of Certificate Authority (CA) public keys (CA certs). If the default
 bundle file isn't adequate, you can specify an alternate file
 using the --cacert option.
If this HTTPS server uses a certificate signed by a CA represented in
 the bundle, the certificate verification probably failed due to a
 problem with the certificate (it might be expired, or the name might
 not match the domain name in the URL).
If you'd like to turn off curl's verification of the certificate, use
 the -k (or --insecure) option.
```

```
$ reattach-to-user-namespace curl https://example.dev/
# HTTP/1.1 200 OK
```