### PR TITLE
Note that this fixes the SSH-passphrase problem.

### DIFF
--- a/Usage.md
+++ b/Usage.md
@@ -192,5 +192,12 @@ alleviate.
     As of macOS Sierra, under tmux without `reattach-to-user-namespace`, `curl`
     will fail to verify peers against Keychain-stored certificates.
 
+* `ssh` - Keychain access for Secure Shell
+
+    On macOS Sierra *tmux* can only add your SSH keys to `ssh-agent`
+    with `reattach-to-user-namespace`,
+    see ["macOS Sierra without SSH-passphrase"](https://youtu.be/w5iZkhlg24M)
+    on YouTube.
+
 There may also be other contexts (aside from “inside *tmux*”) where
 these same problems occur, but I have not yet heard of any.


### PR DESCRIPTION
Hello Chris,

I've had a SSH-Passphrase problem with tmux on macOS Sierra.
`reattach-to-user-namespace` did solve it :-)

Others will run into this too.
So I described the fix and mentioned your project in a short clip
(german with english subtitles):
[macOS Sierra without SSH-Passphrase](https://youtu.be/w5iZkhlg24M).

Thanks a lot for this tool!
Björn