### PR TITLE
Use libxpc to reattach to user namespace on macOS 10.10+

### DIFF
--- a/move_to_user_namespace.c
+++ b/move_to_user_namespace.c
@@ -2,9 +2,11 @@
 #include <stdlib.h>
 #include <unistd.h>
 #include <dlfcn.h>
+
 #include <mach/mach.h>
 #include <servers/bootstrap.h>
-#include <Security/AuthSession.h>
+#include <xpc/xpc.h>
+#include "xpc.h"
 
 #include "msg.h"
 
@@ -41,58 +43,43 @@ static int move_to_user_namespace__100600(void)
     return 0;
 }
 
-#define VPROC_GSK_MGR_NAME 6
-
 static int move_to_user_namespace__101000(void)
 {
-    char *mgr_name = NULL;
+    xpc_object_t dict = xpc_dictionary_create(NULL, NULL, 0);
 
-    FIND_SYMBOL(vproc_swap_string, void *, (void *, int64_t, const char *, char **))
+    xpc_dictionary_set_uint64(dict, "subsystem", 0x3);
+    xpc_dictionary_set_uint64(dict, "routine", 0x343);
+    xpc_dictionary_set_uint64(dict, "handle", 0x0);
+    xpc_dictionary_set_uint64(dict, "type", 0x1);
+    xpc_dictionary_set_uint64(dict, "uid", getuid());
 
-    if (f_vproc_swap_string(NULL, VPROC_GSK_MGR_NAME, NULL, &mgr_name)) {
-        warn("%s failed", fn_vproc_swap_string);
+    kern_return_t kr;
+    xpc_object_t reply;
+    xpc_pipe_t pipe = xpc_pipe_create_from_port(bootstrap_port, 0);
+
+    if (xpc_pipe_routine(pipe, dict, &reply) != 0) {
+        kr = xpc_dictionary_get_uint64(reply, "error");
+        warn("xpc_pipe_routine failed: %d %s", kr, mach_error_string(kr));
         return -1;
     }
 
-    if (strcmp("System", mgr_name) == 0) {
-        kern_return_t kr;
-        mach_port_t puc = MACH_PORT_NULL;
-        mach_port_t rootbs = MACH_PORT_NULL;
+    mach_port_t puc = xpc_dictionary_copy_mach_send(reply, "bootstrap");
 
-        FIND_SYMBOL(bootstrap_get_root, kern_return_t, (mach_port_t, mach_port_t *))
-        FIND_SYMBOL(bootstrap_strerror, const char *, (kern_return_t))
-        FIND_SYMBOL(bootstrap_look_up_per_user, kern_return_t, (mach_port_t, const char *, uid_t, mach_port_t *))
-
-        if ((kr = f_bootstrap_get_root(bootstrap_port, &rootbs)) != KERN_SUCCESS) {
-            warn("%s failed: %d %s", fn_bootstrap_get_root, kr, f_bootstrap_strerror(kr));
-            return -1;
-        }
-
-        if ((kr = f_bootstrap_look_up_per_user(rootbs, NULL, getuid(), &puc)) != KERN_SUCCESS) {
-            warn("%s failed: %d %s", fn_bootstrap_look_up_per_user, kr, f_bootstrap_strerror(kr));
-            return -1;
-        }
-
-
-        if ((kr = task_set_bootstrap_port(mach_task_self(), puc)) != KERN_SUCCESS) {
-            warn("task_set_bootstrap_port failed: %d %s", kr, mach_error_string(kr));
-            return -1;
-        }
-
-       if ((kr = mach_port_deallocate(mach_task_self(), bootstrap_port)) != KERN_SUCCESS) {
-            warn("mach_port_deallocate failed: %d %s", kr, mach_error_string(kr));
-            return -1;
-        }
-
-        bootstrap_port = puc;
-    } else {
-        FIND_SYMBOL(_vprocmgr_detach_from_console, void *, (uint64_t))
-
-        if (f__vprocmgr_detach_from_console(0) != NULL) {
-            warn("%s failed", fn__vprocmgr_detach_from_console);
-            return -1;
-        }
+    if ((kr = task_set_bootstrap_port(mach_task_self(), puc)) != KERN_SUCCESS) {
+        warn("task_set_bootstrap_port failed: %d %s", kr, mach_error_string(kr));
+        return -1;
     }
+
+    if ((kr = mach_port_deallocate(mach_task_self(), bootstrap_port)) != KERN_SUCCESS) {
+        warn("mach_port_deallocate failed: %d %s", kr, mach_error_string(kr));
+        return -1;
+    }
+
+    bootstrap_port = puc;
+
+    xpc_release(pipe);
+    xpc_release(dict);
+    xpc_release(reply);
 
     return 0;
 }

--- a/move_to_user_namespace.c
+++ b/move_to_user_namespace.c
@@ -41,31 +41,12 @@ static int move_to_user_namespace__100600(void)
 
 static int move_to_user_namespace__101000(void)
 {
-    mach_port_t puc = MACH_PORT_NULL;
-    mach_port_t rootbs = MACH_PORT_NULL;
+    FIND_SYMBOL(_vprocmgr_detach_from_console, void *, (uint64_t))
 
-    FIND_SYMBOL(bootstrap_get_root, kern_return_t, (mach_port_t, mach_port_t *))
-    FIND_SYMBOL(bootstrap_look_up_per_user, kern_return_t, (mach_port_t, const char *, uid_t, mach_port_t *))
-
-    if (f_bootstrap_get_root(bootstrap_port, &rootbs) != KERN_SUCCESS) {
-        warn("%s failed", fn_bootstrap_get_root);
+    if (f__vprocmgr_detach_from_console(0) != NULL) {
+        warn("%s failed: can't detach from console", fn__vprocmgr_detach_from_console);
         return -1;
     }
-    if (f_bootstrap_look_up_per_user(rootbs, NULL, getuid(), &puc) != KERN_SUCCESS) {
-        warn("%s failed", fn_bootstrap_look_up_per_user);
-        return -1;
-    }
-
-    if (task_set_bootstrap_port(mach_task_self(), puc) != KERN_SUCCESS) {
-        warn("task_set_bootstrap_port failed");
-        return -1;
-    }
-    if (mach_port_deallocate(mach_task_self(), bootstrap_port) != KERN_SUCCESS) {
-        warn("mach_port_deallocate failed");
-        return -1;
-    }
-
-    bootstrap_port = puc;
 
     return 0;
 }

--- a/xpc.h
+++ b/xpc.h
@@ -1,0 +1,11 @@
+
+typedef struct _xpc_pipe_s* xpc_pipe_t;
+
+xpc_pipe_t xpc_pipe_create_from_port(mach_port_t port, int flags);
+
+mach_port_t xpc_dictionary_copy_mach_send(xpc_object_t dict, const char *name);
+
+int xpc_pipe_routine(xpc_pipe_t pipe,
+                     xpc_object_t request,
+                     xpc_object_t *reply);
+


### PR DESCRIPTION
This change makes the move_to_user_namespace implementation use the
undocumented `_vprocmgr_detach_from_console` function (**OUTDATED** see 4th comment) to reattach to user
namespace for macOS versions 10.10+.

The current implementation moves the process to the user's "per-user"
bootstrap namespace. However, Apple's distribution of GNU screen moves
the process to the user's "per-session" bootstrap namespace using the
`_vprocmgr_detach_from_console` function since macOS Mavericks (10.09)

Moving the process to the user's per-session bootstrap namespace has
as benefit that things like the `pam_tid` module (Touch ID support for PAM)
work correctly with this program. This may be related to the fact that
processes that are using the per-session namespace can see its parent
per-user namespace, but processes using the per-user namespace cannot see
processes using the per-session namespace (as mentioned in
https://developer.apple.com/library/archive/technotes/tn2083/_index.html)

Additionally, this approach simplifies the implementation a bit.

If you are already using the `pam_tid` module for sudo, you can verify
the patch by running the following command with the pre-patched and
patched program:

```sh
$ reattach-to-user-namespace sudo su

```

The patched program should show a popup for authenticating via Touch ID.