### PR TITLE
Remove i386 from ARCHES since it has been removed from XCode and make fails

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
-# use for ppc support:
+# use for ppc or i386 support:
 # ARCHES = i386 ppc x86_64
-ARCHES = i386 x86_64
+ARCHES = x86_64
 ARCH_FLAGS = $(ARCHES:%=-arch %)
 
 CFLAGS ?= -Wall -Wextra -ansi -pedantic -std=c99


### PR DESCRIPTION
Make fails due to i386 has been entirely removed from XCode on modern versions of macOS.